### PR TITLE
Empêcher l'interprétation des symboles

### DIFF
--- a/send-notification.sh
+++ b/send-notification.sh
@@ -57,7 +57,7 @@ else # Message lu de STDIN
     do
         MESSAGE_TO_SEND="$MESSAGE_TO_SEND$line$NEWLINE_CHAR"
     done
-    MESSAGE_TO_SEND=$(echo $MESSAGE_TO_SEND | sed 's/'$NEWLINE_CHAR'$//') # Retire le dernier saut de ligne
+    MESSAGE_TO_SEND=$(echo "$MESSAGE_TO_SEND" | sed 's/'$NEWLINE_CHAR'$//') # Retire le dernier saut de ligne
 fi
 
 FINAL_MESSAGE_TO_SEND="$MESSAGE_HEADER$MESSAGE_TO_SEND$MESSAGE_FOOTER" # Assemble header, message et footer


### PR DESCRIPTION
Les doubles quotes empêchent l'interprétation des symboles (si le SMS envoyé commence par une astérisque "*" par exemple)
